### PR TITLE
Change cursor in manual TOC

### DIFF
--- a/asset/scss/blocks/_manual.scss
+++ b/asset/scss/blocks/_manual.scss
@@ -8,6 +8,7 @@
         }
 
         h2 {
+            cursor: pointer;
             font-size: 1.25em;
             margin-top: 0;
             margin-bottom: 0.5em;

--- a/asset/scss/blocks/_manual.scss
+++ b/asset/scss/blocks/_manual.scss
@@ -11,7 +11,8 @@
             cursor: pointer;
             font-size: 1.25em;
             margin-top: 0;
-            margin-bottom: 0.5em;
+            padding-bottom: 0.5em;
+            margin-bottom: 0;
         }
 
         ul {


### PR DESCRIPTION
Adds `cursor: pointer` to manual TOC CSS for section headers, ensuring it's clear they are clickable.